### PR TITLE
Protect against Regex-Denial-of-Service attack by doing timebound matching

### DIFF
--- a/src/main/java/com/panforge/robotstxt/Access.java
+++ b/src/main/java/com/panforge/robotstxt/Access.java
@@ -15,6 +15,8 @@
  */
 package com.panforge.robotstxt;
 
+import com.panforge.robotstxt.exception.MatchingTimeoutException;
+
 import java.util.List;
 
 /**
@@ -65,8 +67,9 @@ class Access implements Grant {
    * @param path path to check
    * @param matchingStrategy matcher
    * @return <code>true</code> if path matches access path
+   * @throws MatchingTimeoutException on failure to match within specific time period.
    */
-  public boolean matches(String path, MatchingStrategy matchingStrategy) {
+  public boolean matches(String path, MatchingStrategy matchingStrategy) throws MatchingTimeoutException {
     return path!=null && matchingStrategy.matches(clause, path);
   }
   

--- a/src/main/java/com/panforge/robotstxt/AccessList.java
+++ b/src/main/java/com/panforge/robotstxt/AccessList.java
@@ -15,6 +15,9 @@
  */
 package com.panforge.robotstxt;
 
+import com.panforge.robotstxt.exception.MatchingTimeoutException;
+import com.panforge.robotstxt.exception.SelectionException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -51,18 +54,40 @@ class AccessList {
    * @param relativePath path to test
    * @param matchingStrategy matcher
    * @return list of matching elements
+   * @throws SelectionException when we are unable to select with certainty.
+   * i.e. when we have successfully determined that most of the access clauses don't match the path but,
+   * matching for some for the access clauses timed out
+   * (we were not able to determine in a specified time frame - possible regex DOS attack.), so
+   * we throw a selection exception to inform the caller that the selection process had hiccups
+   * as some of the access clauses could not evaluated.
+   * if all the access clauses are evaluated successfully and still no selection is available, then we do-not throw selectionException,
+   * as all clauses were evaluated.
+   * if some of the access clauses are evaluated successfully and some timeout, but selection is available, then we do-not throw selectionException,
+   * as a selection is available.
    */
-  public List<Access> select(String relativePath, MatchingStrategy matchingStrategy) {
+  public List<Access> select(String relativePath, MatchingStrategy matchingStrategy) throws SelectionException {
     ArrayList<Access> allMatching = new ArrayList<Access>();
-    
+
+    Exception latestMatchingTimeoutException = null;
+    String latestTimedOutAccessClause = null;
     if (relativePath!=null) {
       for (Access acc: accessList) {
-        if (acc.matches(relativePath, matchingStrategy)) {
-          allMatching.add(acc);
+        try {
+          if (acc.matches(relativePath, matchingStrategy)) {
+            allMatching.add(acc);
+          }
+        } catch (MatchingTimeoutException e) {
+          latestMatchingTimeoutException = e;
+          latestTimedOutAccessClause = acc.getClause();
         }
       }
+      //if timeout occurs in matching but some other matches have succeeded, then go ahead with what you have got. else .. throw exception
+      if(allMatching.size() == 0 && latestMatchingTimeoutException != null){
+        //since no match was possible at all & we detected timeout atleast once i.e. unable to determine a match. lets tell the caller about this.
+        throw new SelectionException("All Access clauses could not be evaluated & no access paths! We could not decide for some access paths because the matching timed out. Latest Timed Out Access Clause: " + latestTimedOutAccessClause, latestMatchingTimeoutException);
+      }
     }
-    
+
     return allMatching;
   }
   

--- a/src/main/java/com/panforge/robotstxt/Group.java
+++ b/src/main/java/com/panforge/robotstxt/Group.java
@@ -15,6 +15,8 @@
  */
 package com.panforge.robotstxt;
 
+import com.panforge.robotstxt.exception.SelectionException;
+
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -93,12 +95,13 @@ class Group {
    * @param relativePath path to test
    * @param matchingStrategy matcher
    * @return list of matching elements
+   * @throws SelectionException if unable to select
    */
-  public List<Access> select(String userAgent, String relativaPath, MatchingStrategy matchingStrategy) {
-    if ((userAgent==null && !isAnyAgent()) || relativaPath==null || !matchUserAgent(userAgent)) {
+  public List<Access> select(String userAgent, String relativePath, MatchingStrategy matchingStrategy) throws SelectionException {
+    if ((userAgent==null && !isAnyAgent()) || relativePath==null || !matchUserAgent(userAgent)) {
       return Collections.EMPTY_LIST;
     }
-    return accessList.select(relativaPath, matchingStrategy).stream().collect(Collectors.toList());
+    return accessList.select(relativePath, matchingStrategy).stream().collect(Collectors.toList());
   }
   
   /**

--- a/src/main/java/com/panforge/robotstxt/RobotsTxt.java
+++ b/src/main/java/com/panforge/robotstxt/RobotsTxt.java
@@ -15,6 +15,8 @@
  */
 package com.panforge.robotstxt;
 
+import com.panforge.robotstxt.exception.QueryExecutionException;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Collections;
@@ -32,16 +34,18 @@ public interface RobotsTxt {
    * @param userAgent user agent to be used evaluate authorization
    * @param path path to access
    * @return <code>true</code> if there is an access to the requested path
+   * @throws QueryExecutionException on failure to execute query
    */
-  boolean query(String userAgent, String path);
+  boolean query(String userAgent, String path) throws QueryExecutionException;
   
   /**
    * Asks for grant.
    * @param userAgent user agent to be used evaluate authorization
    * @param path path to access
    * @return grant (never <code>null</code>)
+   * @throws QueryExecutionException on failure to execute query
    */
-  default Grant ask(String userAgent, String path) {
+  default Grant ask(String userAgent, String path) throws QueryExecutionException{
     return new Grant() {
       @Override
       public boolean hasAccess() {
@@ -102,4 +106,18 @@ public interface RobotsTxt {
       RobotsTxtReader reader = new RobotsTxtReader();
       return reader.readRobotsTxt(input);
   }
+
+  /**
+   * Reads robots.txt available at the URL using provided strategies.
+   * @param input stream of content
+   * @param matchingStrategy
+   * @param winningStrategy
+   * @return parsed robots.txt object
+   * @throws IOException if unable to read content.
+   */
+  static RobotsTxt read(InputStream input, MatchingStrategy matchingStrategy, WinningStrategy winningStrategy) throws IOException {
+    RobotsTxtReader reader = new RobotsTxtReader(matchingStrategy, winningStrategy);
+    return reader.readRobotsTxt(input);
+  }
+
 }

--- a/src/main/java/com/panforge/robotstxt/exception/MatchingTimeoutException.java
+++ b/src/main/java/com/panforge/robotstxt/exception/MatchingTimeoutException.java
@@ -1,0 +1,11 @@
+package com.panforge.robotstxt.exception;
+
+/**
+ * failed to match within specific timeout
+ * @author vishnu rao
+ */
+public class MatchingTimeoutException extends Exception {
+    public MatchingTimeoutException(int timeoutMs) {
+        super("Failed to do a match within time period of " + timeoutMs + " ms.");
+    }
+}

--- a/src/main/java/com/panforge/robotstxt/exception/QueryExecutionException.java
+++ b/src/main/java/com/panforge/robotstxt/exception/QueryExecutionException.java
@@ -1,0 +1,16 @@
+package com.panforge.robotstxt.exception;
+
+/**
+ * Failure to Execute query
+ * @author vishnu rao
+ */
+public class QueryExecutionException extends Exception {
+
+    public QueryExecutionException(String message) {
+        super(message);
+    }
+
+    public QueryExecutionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/panforge/robotstxt/exception/SelectionException.java
+++ b/src/main/java/com/panforge/robotstxt/exception/SelectionException.java
@@ -1,0 +1,15 @@
+package com.panforge.robotstxt.exception;
+
+/**
+ * unable to select.
+ * @author vishnu rao
+ */
+public class SelectionException extends Exception{
+    public SelectionException(String message) {
+        super(message);
+    }
+
+    public SelectionException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/panforge/robotstxt/matching/TimeLimitedMatcherFactory.java
+++ b/src/main/java/com/panforge/robotstxt/matching/TimeLimitedMatcherFactory.java
@@ -1,0 +1,145 @@
+package com.panforge.robotstxt.matching;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * A factory class used to generate Matcher instances that will
+ * throw if in use after their timeout.
+ * @Author : Credit goes to https://www.exratione.com/2017/06/preventing-unbounded-regular-expression-operations-in-java/
+ */
+public abstract class TimeLimitedMatcherFactory {
+    // If a regular expression requires more than a couple of seconds
+    // to complete, then it has no place in polite society.
+    private static final long DEFAULT_TIMEOUT_MS = 2000L;
+
+    /**
+     * Generate a Matcher instance that will throw if used or still
+     * in use more than timeoutInMilliseconds after its instantiation.
+     * <p>
+     * Use the instance immediately and then discard it.
+     *
+     * @param pattern               The Pattern instance.
+     * @param charSequence          The CharSequence to operate on.
+     * @param timeoutInMilliseconds Throw after this timeout is reached.
+     */
+    public static Matcher matcher(
+            Pattern pattern,
+            CharSequence charSequence,
+            long timeoutInMilliseconds
+    ) {
+        // Substitute in our exploding CharSequence implementation.
+        if (!(charSequence instanceof TimeLimitedCharSequence)) {
+            charSequence = new TimeLimitedCharSequence(
+                    charSequence,
+                    timeoutInMilliseconds,
+                    pattern,
+                    charSequence
+            );
+        }
+
+        return pattern.matcher(charSequence);
+    }
+
+    /**
+     * Generate a Matcher instance that will throw if used or still
+     * in use more than 2 seconds after its instantiation.
+     * <p>
+     * Use the instance immediately and then discard it.
+     *
+     * @param pattern      The Pattern instance.
+     * @param charSequence The CharSequence to operate on.
+     */
+    public static Matcher matcher(
+            Pattern pattern,
+            CharSequence charSequence
+    ) {
+        return matcher(pattern, charSequence, DEFAULT_TIMEOUT_MS);
+    }
+
+    /**
+     * An exception to indicate that a regular expression operation
+     * timed out.
+     */
+    public static class RegExpTimeoutException extends RuntimeException {
+        public RegExpTimeoutException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * A CharSequence implementation that throws when charAt() is called
+     * after a given timeout.
+     * <p>
+     * Since charAt() is invoked frequently in regular expression operations
+     * on a string, this gives a way to abort long-running regular expression
+     * operations.
+     */
+    private static class TimeLimitedCharSequence implements CharSequence {
+        private final CharSequence inner;
+        private final long timeoutInMilliseconds;
+        private long timeoutAfterTimestamp = -1;//-1 indicates not yet initialized to proper value.
+        private final Pattern pattern;
+        private final CharSequence originalCharSequence;
+
+        /**
+         * Default constructor.
+         *
+         * @param inner                 The CharSequence to wrap. This may be a subsequence of the original.
+         * @param timeoutInMilliseconds How long before calls to charAt() throw.
+         * @param pattern               The Pattern instance; only used for logging purposes.
+         * @param originalCharSequence  originalCharSequence The original sequence, used for logging purposes.
+         */
+        public TimeLimitedCharSequence(
+                CharSequence inner,
+                long timeoutInMilliseconds,
+                Pattern pattern,
+                CharSequence originalCharSequence
+        ) {
+            super();
+            this.inner = inner;
+            this.timeoutInMilliseconds = timeoutInMilliseconds;
+            // Carry out this calculation here, once, rather than every time
+            // charAt() is invoked. Little optimizations make the world turn.
+            timeoutAfterTimestamp = System.currentTimeMillis() + timeoutInMilliseconds;
+            this.pattern = pattern;
+            this.originalCharSequence = originalCharSequence;
+        }
+
+        public char charAt(int index) {
+            // This is an unavoidable slowdown, but what can you do?
+            if (System.currentTimeMillis() > timeoutAfterTimestamp) {
+                // Note that we add the original charsequence to the exception
+                // message. This condition can be met on a subsequence of the
+                // original sequence, and the subsequence string is rarely
+                // anywhere near as helpful.
+                throw new RegExpTimeoutException(
+                        "Regular expression timeout after " + timeoutInMilliseconds
+                                + "ms for [ " + pattern.pattern() + " ] operating on [ "
+                                + originalCharSequence + " ]"
+                );
+            }
+            return inner.charAt(index);
+        }
+
+        public int length() {
+            return inner.length();
+        }
+
+        public CharSequence subSequence(int start, int end) {
+            // Ensure that any subsequence generated during a regular expression
+            // operation is still going to explode on time.
+            return new TimeLimitedCharSequence(
+                    inner.subSequence(start, end),
+                    timeoutAfterTimestamp - System.currentTimeMillis(),
+                    pattern,
+                    originalCharSequence
+            );
+        }
+
+        @Override
+        public String toString() {
+            return inner.toString();
+        }
+    }
+}

--- a/src/test/resources/robots_with_suspicious_rule.txt
+++ b/src/test/resources/robots_with_suspicious_rule.txt
@@ -1,0 +1,7 @@
+# Pues aquí el típico user-agent abierto pá tol mundo.
+User-agent: *
+
+
+# The following rules create havoc while doing regex match, which result in https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS
+Allow: **********.css
+Allow: **********.js


### PR DESCRIPTION
Prevent against Regex Denial of Service attack.

o- some robots.txt have rules like "Allow: **********.css"
o- so regex matching a url against such a rule can take years to complete.
o- this pr is about introducing a time limit while doing regex matching.
Note:
o- if some rules in robots.txt  evaluate negative & some time out, then we throw an exception to caller to indicate that the we could not evaluate all rules properly, so that he may choose what to do.
o- if some rules in robots.txt  evaluate positive & some time out, then no exception is thrown(i.e. timeouts are ignored)
o- if all rules in robots.txt  evaluate negative, then no exception is thrown.


reference:
https:// www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS